### PR TITLE
fix: rename project name for installing with poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "behavior-trees"
+name = "cyberdyne"
 version = "0.1.0"
 description = "A friendly Python library for (asynchronous) behavior trees."
 authors = [


### PR DESCRIPTION
Fixes the error when installing cyberdyne with poetry

```
[tool.poetry.dependencies]
python = "^3.9"
...
cyberdyne = {git = "https://github.com/stereobutter/cyberdyne.git", rev = "main"}
```

Error when run `poetry install`:

`The dependency name for cyberdyne does not match the actual package's name: behavior-trees`